### PR TITLE
WIP: implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ hexadecimal	= "0x" hexdigit { hexdigit };
 binary		= "0b" bindigit { bindigit };
 
 number		= decimal | hexadecimal | binary;
-ident		= alphanum {alphanum};
+ident		= letter {alphanum};
 binaryop	= "&" | "|" | "^" | "<<" | ">>";
 unaryop		= "~";
 expr		= [ "(" ] unaryexpr | binaryexpr [ ")" ];

--- a/README.md
+++ b/README.md
@@ -45,21 +45,21 @@ bwc>
 # The language
 
 ```bnf
-letter 		= "a".."z" | "A".."Z";
-digit 		= "0".."9";
-alphanum 	= letter | digit;
+letter		= "a".."z" | "A".."Z";
+digit		= "0".."9";
+alphanum	= letter | digit;
 
 decdigit = "0".."9";
 hexdigit = decdigit | "a".."f";
 bindigit = "0" | "1";
 
-decimal 	= decdigit { decdigit };
+decimal		= decdigit { decdigit };
 hexadecimal	= "0x" hexdigit { hexdigit };
 binary		= "0b" bindigit { bindigit };
 
-number 	= decimal | hexadecimal | binary;
+number	= decimal | hexadecimal | binary;
 ident	= alphanum {alphanum};
-op	= "&" | "|" | "<<" | ">>";
+op		= "&" | "|" | "<<" | ">>";
 expr	= 	[ "(" ] (expr | number) op (expr | number) [ ")" ];
 
 grammar = number | ident | expr;

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ decdigit 	= "0".."9";
 hexdigit 	= decdigit | "a".."f";
 bindigit 	= "0" | "1";
 
-decimal		= decdigit { decdigit };
+decimal	= decdigit { decdigit };
 hexadecimal	= "0x" hexdigit { hexdigit };
 binary		= "0b" bindigit { bindigit };
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Because I'm dumb.
 
-# language
+# The tool
 
 The language was designed in a such a way that
 makes easy to copy-paste bitwises from code
@@ -40,4 +40,27 @@ bwc> X
 bin: 11111111
 hex: ff
 bwc>
+```
+
+# The language
+
+```bnf
+letter 		= "a".."z" | "A".."Z";
+digit 		= "0".."9";
+alphanum 	= letter | digit;
+
+decdigit = "0".."9";
+hexdigit = decdigit | "a".."f";
+bindigit = "0" | "1";
+
+decimal 	= decdigit { decdigit };
+hexadecimal	= "0x" hexdigit { hexdigit };
+binary		= "0b" bindigit { bindigit };
+
+number 	= decimal | hexadecimal | binary;
+ident	= alphanum {alphanum};
+op	= "&" | "|" | "<<" | ">>";
+expr	= 	[ "(" ] (expr | number) op (expr | number) [ ")" ];
+
+grammar = number | ident | expr;
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Because I'm dumb.
 The language was designed in a such a way that
 makes easy to copy-paste bitwises from code
 in most programming languages (at least from
-C generation). Take a look in the code below:
+C descendents). Take a look in the code below:
 
 ```go
 func stripe(val uint32) uint64 {

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ letter		= "a".."z" | "A".."Z";
 digit		= "0".."9";
 alphanum	= letter | digit;
 
-decdigit = "0".."9";
-hexdigit = decdigit | "a".."f";
-bindigit = "0" | "1";
+decdigit 	= "0".."9";
+hexdigit 	= decdigit | "a".."f";
+bindigit 	= "0" | "1";
 
 decimal		= decdigit { decdigit };
 hexadecimal	= "0x" hexdigit { hexdigit };

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ bwc>
 
 ```bnf
 letter		= "a".."z" | "A".."Z";
-digit		= "0".."9";
-alphanum	= letter | digit;
+alphanum	= letter | decdigit;
 
 decdigit 	= "0".."9";
 hexdigit 	= decdigit | "a".."f";

--- a/README.md
+++ b/README.md
@@ -4,16 +4,40 @@ Because I'm dumb.
 
 # language
 
-Mathematical reverse polish notation language.
+The language was designed in a such a way that
+makes easy to copy-paste bitwises from code
+in most programming languages (at least from
+C generation). Take a look in the code below:
 
-Only two operands per operation.
+```go
+func stripe(val uint32) uint64 {
+	X := uint64(val)
+	X = (X | (X << 16)) & 0x0000ffff0000ffff
+	X = (X | (X << 8)) & 0x00ff00ff00ff00ff
+	X = (X | (X << 4)) & 0x0f0f0f0f0f0f0f0f
+	X = (X | (X << 2)) & 0x3333333333333333
+	X = (X | (X << 1)) & 0x5555555555555555
+	return X
+}
+```
+
+To understand this code you should define X and
+then copy the lines or parts of the bitwise you 
+are interested in. For example:
 
 ```
-% bwc
-> 1 2 &
-bin: 00000000
-hex: 00000000
-> 1 2 |
-bin: 00000011
-hex: 00000003
+$ bwc
+# Define the variable
+bwc> X = 0xff
+bin: 11111111
+hex: ff
+
+# Paste the code
+bwc> X = (X | (X << 16)) & 0x0000ffff0000ffff
+
+# eval X
+bwc> X
+bin: 11111111
+hex: ff
+bwc>
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,22 @@ bwc> X = (X | (X << 16)) & 0x0000ffff0000ffff
 bwc> X
 bin: 11111111
 hex: ff
-bwc>
+
+# paste the rest of the statements
+bwc> X = (X | (X << 8)) & 0x00ff00ff00ff00ff
+bin: 11111111
+hex: ff
+bwc> X = (X | (X << 4)) & 0x0f0f0f0f0f0f0f0f
+bin: 111100001111
+hex: f0f
+bwc> X = (X | (X << 2)) & 0x3333333333333333
+bin: 11001100110011
+hex: 3333
+bwc> X = (X | (X << 1)) & 0x5555555555555555
+bin: 101010101010101
+hex: 5555
+
+# hmm, bit interleaving =)
 ```
 
 # The language

--- a/README.md
+++ b/README.md
@@ -57,10 +57,14 @@ decimal	= decdigit { decdigit };
 hexadecimal	= "0x" hexdigit { hexdigit };
 binary		= "0b" bindigit { bindigit };
 
-number	= decimal | hexadecimal | binary;
-ident	= alphanum {alphanum};
-op	= "&" | "|" | "<<" | ">>";
-expr	= 	[ "(" ] (expr | number) op (expr | number) [ ")" ];
+number		= decimal | hexadecimal | binary;
+ident		= alphanum {alphanum};
+binaryop	= "&" | "|" | "^" | "<<" | ">>";
+unaryop		= "~";
+expr		= [ "(" ] unaryexpr | binaryexpr [ ")" ];
+binaryexpr	= (expr | binaryexpr | unaryexpr | number) binaryop 
+				(expr | unaryexpr | binaryexpr | number);
+unaryexpr	= unaryop (expr | unaryexpr | binaryexpr | number);
 
 grammar = number | ident | expr;
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ binary		= "0b" bindigit { bindigit };
 
 number	= decimal | hexadecimal | binary;
 ident	= alphanum {alphanum};
-op		= "&" | "|" | "<<" | ">>";
+op	= "&" | "|" | "<<" | ">>";
 expr	= 	[ "(" ] (expr | number) op (expr | number) [ ")" ];
 
 grammar = number | ident | expr;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bwc - bitwise calculator
 
-Because I'm dumb.
+Because bitwises are trick.
 
 # The tool
 
@@ -60,10 +60,13 @@ number		= decimal | hexadecimal | binary;
 ident		= letter {alphanum};
 binaryop	= "&" | "|" | "^" | "<<" | ">>";
 unaryop		= "~";
-expr		= [ "(" ] unaryexpr | binaryexpr [ ")" ];
-binaryexpr	= (expr | binaryexpr | unaryexpr | number) binaryop 
-				(expr | unaryexpr | binaryexpr | number);
-unaryexpr	= unaryop (expr | unaryexpr | binaryexpr | number);
+mathexpr	= [ "(" ] unaryexpr | binaryexpr [ ")" ];
+operand		= expr | binaryexpr | unaryexpr | number;
+binaryexpr	= operand binaryop operand;
+unaryexpr	= unaryop operand;
+expr		= number | ident | mathexpr;
 
-grammar = number | ident | expr;
+assignment	= ident "=" expr;
+
+grammar		= assignment | expr;
 ```

--- a/eval_test.go
+++ b/eval_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+var format = fmt.Sprintf
+
+func desc(a Expr, res Int) string {
+	return format("%s %s %s = %s",
+		a.Lhs, a.Rhs, a.Op, res)
+}
+
+func TestEval(t *testing.T) {
+	for _, tc := range []struct {
+		expr Expr
+		res  Int
+	}{
+		{
+			expr: Expr{
+				Op:  OpAND,
+				Lhs: Int(0),
+				Rhs: Int(0),
+			},
+			res: 0,
+		},
+		{
+			expr: Expr{
+				Op:  OpAND,
+				Lhs: Int(0),
+				Rhs: Int(1),
+			},
+			res: 0,
+		},
+		{
+			expr: Expr{
+				Op:  OpAND,
+				Lhs: Int(1),
+				Rhs: Int(1),
+			},
+			res: 1,
+		},
+		{
+			expr: Expr{
+				Op:  OpAND,
+				Lhs: Int(0xffff0000),
+				Rhs: Int(0x0000ffff),
+			},
+			res: 0,
+		},
+		{
+			expr: Expr{
+				Op:  OpOR,
+				Lhs: Int(0xffff0000),
+				Rhs: Int(0x0000ffff),
+			},
+			res: 0xffffffff,
+		},
+
+		// groups
+		{
+			expr: Expr{
+				Op: OpAND,
+				Lhs: Expr{
+					Op:  OpOR,
+					Lhs: Int(0xffff0000),
+					Rhs: Int(0x0000ffff),
+				},
+				Rhs: Int(0x000000ff),
+			},
+			res: 0x000000ff,
+		},
+		{
+			expr: Expr{
+				Op: OpOR,
+				Lhs: Expr{
+					Op:  OpOR,
+					Lhs: Int(0x000000ff),
+					Rhs: Int(0xff000000),
+				},
+				Rhs: Expr{
+					Op:  OpOR,
+					Lhs: Int(0x00ff0000),
+					Rhs: Int(0x0000ff00),
+				},
+			},
+			res: 0xffffffff,
+		},
+	} {
+		tc := tc
+		t.Run(desc(tc.expr, tc.res), func(t *testing.T) {
+			got := Eval(tc.expr)
+			if got != tc.res {
+				t.Fatalf("Fail: %d != %d", got, tc.res)
+			}
+		})
+	}
+}

--- a/infix/ast.go
+++ b/infix/ast.go
@@ -68,20 +68,27 @@ func (o Optype) String() string {
 	return "<invalid op>"
 }
 
+func (nt Nodetype) String() string {
+	if nt == NodeUnaryExpr {
+		return "NodeUnaryExpr"
+	} else if nt == NodeBinExpr {
+		return "NodeBinExpr"
+	} else if nt == NodeInt {
+		return "NodeInt"
+	}
+	return "<invalid node>"
+}
+
 func (_ Int) Type() Nodetype { return NodeInt }
 func (i Int) String() string { return strconv.Itoa(int(i)) }
 
 func (_ BinExpr) Type() Nodetype { return NodeBinExpr }
 func (a BinExpr) String() string {
-	lhs := a.Lhs.String()
-	rhs := a.Rhs.String()
-	op := a.Op.String()
-
-	return fmt.Sprintf("%s %s %s", lhs, rhs, op)
+	return fmt.Sprintf("%s%s%s", a.Lhs, a.Op, a.Rhs)
 }
 
 func (_ UnaryExpr) Type() Nodetype { return NodeUnaryExpr }
 func (a UnaryExpr) String() string {
 	return fmt.Sprintf("%s%s",
-		a.Op.String(), a.Value.String())
+		a.Op, a.Value)
 }

--- a/infix/ast.go
+++ b/infix/ast.go
@@ -6,8 +6,17 @@ import (
 )
 
 type (
-	Int  int64
-	Expr struct {
+	// Int represents integer numbers
+	Int int64
+
+	// UnaryExpr holds unary operations like ~
+	UnaryExpr struct {
+		Op    Optype
+		Value Node
+	}
+
+	// BinExpr holds binary operations like &,|,etc
+	BinExpr struct {
 		Op  Optype
 		Lhs Node
 		Rhs Node
@@ -23,33 +32,56 @@ type (
 )
 
 const (
-	NodeExpr Nodetype = iota + 1
+	NodeUnaryExpr Nodetype = iota + 1
+	NodeBinExpr
 	NodeInt
 
-	OpAND Optype = iota + 1
-	OpOR
+	binaryOPbegin Optype = iota + 1
+	OpAND
+	OpOR 
+	OpXOR
 	OpSHL
 	OpSHR
+	binaryOPend
+
+	unaryOPbegin
+	OpNOT
+	unaryOPend
 )
 
 func (o Optype) String() string {
-	if o == OpAND {
+	switch o {
+	case OpAND:
 		return "&"
-	}
-	if o == OpOR {
+	case OpOR:
 		return "|"
+	case OpXOR:
+		return "^"
+	case OpNOT:
+		return "~"
+	case OpSHL:
+		return "<<"
+	case OpSHR:
+		return ">>"
 	}
+
 	return "<invalid op>"
 }
 
 func (_ Int) Type() Nodetype { return NodeInt }
 func (i Int) String() string { return strconv.Itoa(int(i)) }
 
-func (_ Expr) Type() Nodetype { return NodeExpr }
-func (a Expr) String() string {
+func (_ BinExpr) Type() Nodetype { return NodeBinExpr }
+func (a BinExpr) String() string {
 	lhs := a.Lhs.String()
 	rhs := a.Rhs.String()
 	op := a.Op.String()
 
 	return fmt.Sprintf("%s %s %s", lhs, rhs, op)
+}
+
+func (_ UnaryExpr) Type() Nodetype { return NodeUnaryExpr }
+func (a UnaryExpr) String() string {
+	return fmt.Sprintf("%s%s",
+		a.Op.String(), a.Value.String())
 }

--- a/infix/ast.go
+++ b/infix/ast.go
@@ -87,6 +87,8 @@ func (nt Nodetype) String() string {
 		return "NodeInt"
 	} else if nt == NodeAssign {
 		return "NodeAssign"
+	} else if nt == NodeVar {
+		return "NodeVar"
 	}
 	panic(fmt.Sprintf("invalid node: %d", nt))
 }

--- a/infix/ast.go
+++ b/infix/ast.go
@@ -28,6 +28,8 @@ const (
 
 	OpAND Optype = iota + 1
 	OpOR
+	OpSHL
+	OpSHR
 )
 
 func (o Optype) String() string {

--- a/infix/ast.go
+++ b/infix/ast.go
@@ -1,0 +1,53 @@
+package infix
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type (
+	Int  int64
+	Expr struct {
+		Op  Optype
+		Lhs Node
+		Rhs Node
+	}
+
+	Node interface {
+		Type() Nodetype
+		String() string
+	}
+
+	Nodetype int
+	Optype   int
+)
+
+const (
+	NodeExpr Nodetype = iota + 1
+	NodeInt
+
+	OpAND Optype = iota + 1
+	OpOR
+)
+
+func (o Optype) String() string {
+	if o == OpAND {
+		return "&"
+	}
+	if o == OpOR {
+		return "|"
+	}
+	return "<invalid op>"
+}
+
+func (_ Int) Type() Nodetype { return NodeInt }
+func (i Int) String() string { return strconv.Itoa(int(i)) }
+
+func (_ Expr) Type() Nodetype { return NodeExpr }
+func (a Expr) String() string {
+	lhs := a.Lhs.String()
+	rhs := a.Rhs.String()
+	op := a.Op.String()
+
+	return fmt.Sprintf("%s %s %s", lhs, rhs, op)
+}

--- a/infix/ast.go
+++ b/infix/ast.go
@@ -9,6 +9,9 @@ type (
 	// Int represents integer numbers
 	Int int64
 
+	// Var is a variable
+	Var string
+
 	// UnaryExpr holds unary operations like ~
 	UnaryExpr struct {
 		Op    Optype
@@ -20,6 +23,11 @@ type (
 		Op  Optype
 		Lhs Node
 		Rhs Node
+	}
+
+	Assign struct {
+		Varname string // Varname is the lhs of the assignment
+		Expr    Node   // Expr is the rhs of the assignment
 	}
 
 	Node interface {
@@ -34,11 +42,13 @@ type (
 const (
 	NodeUnaryExpr Nodetype = iota + 1
 	NodeBinExpr
+	NodeAssign
 	NodeInt
+	NodeVar
 
 	binaryOPbegin Optype = iota + 1
 	OpAND
-	OpOR 
+	OpOR
 	OpXOR
 	OpSHL
 	OpSHR
@@ -65,7 +75,7 @@ func (o Optype) String() string {
 		return ">>"
 	}
 
-	return "<invalid op>"
+	panic(fmt.Sprintf("invalid operation: %d", o))
 }
 
 func (nt Nodetype) String() string {
@@ -75,12 +85,17 @@ func (nt Nodetype) String() string {
 		return "NodeBinExpr"
 	} else if nt == NodeInt {
 		return "NodeInt"
+	} else if nt == NodeAssign {
+		return "NodeAssign"
 	}
-	return "<invalid node>"
+	panic(fmt.Sprintf("invalid node: %d", nt))
 }
 
 func (_ Int) Type() Nodetype { return NodeInt }
 func (i Int) String() string { return strconv.Itoa(int(i)) }
+
+func (_ Var) Type() Nodetype { return NodeVar }
+func (a Var) String() string { return string(a) }
 
 func (_ BinExpr) Type() Nodetype { return NodeBinExpr }
 func (a BinExpr) String() string {
@@ -91,4 +106,9 @@ func (_ UnaryExpr) Type() Nodetype { return NodeUnaryExpr }
 func (a UnaryExpr) String() string {
 	return fmt.Sprintf("%s%s",
 		a.Op, a.Value)
+}
+
+func (_ Assign) Type() Nodetype { return NodeAssign }
+func (a Assign) String() string {
+	return fmt.Sprintf("%s = %s", a.Varname, a.Expr)
 }

--- a/infix/eval.go
+++ b/infix/eval.go
@@ -5,10 +5,8 @@ import (
 )
 
 func Eval(n Node) (Int, error) {
-	var (
-		lhs, rhs Int
-		err error
-	)
+	var lhs, rhs Int
+	var err error
 
 	if n.Type() == NodeInt {
 		return n.(Int), nil

--- a/infix/eval.go
+++ b/infix/eval.go
@@ -16,9 +16,9 @@ func Eval(n Node) (Int, error) {
 		return 0, fmt.Errorf("unexpected %s", n)
 	}
 
-	expr := n.(*Expr)
+	expr := n.(Expr)
 	if expr.Lhs.Type() != NodeInt {
-		lhs, err = Eval(expr.Lhs.(*Expr))
+		lhs, err = Eval(expr.Lhs.(Expr))
 		if err != nil {
 			return 0, err
 		}
@@ -27,7 +27,7 @@ func Eval(n Node) (Int, error) {
 	}
 
 	if expr.Rhs.Type() != NodeInt {
-		rhs, err = Eval(expr.Rhs.(*Expr))
+		rhs, err = Eval(expr.Rhs.(Expr))
 		if err != nil {
 			return 0, err
 		}

--- a/infix/eval.go
+++ b/infix/eval.go
@@ -5,20 +5,40 @@ import (
 )
 
 func Eval(n Node) (Int, error) {
-	var lhs, rhs Int
-	var err error
-
 	if n.Type() == NodeInt {
 		return n.(Int), nil
 	}
 
-	if n.Type() != NodeExpr {
+	if n.Type() == NodeUnaryExpr {
+		return evalUnaryExpr(n.(UnaryExpr))
+	}
+
+	if n.Type() != NodeBinExpr {
 		return 0, fmt.Errorf("unexpected %s", n)
 	}
 
-	expr := n.(Expr)
+	return evalBinExpr(n.(BinExpr))
+}
+
+func evalUnaryExpr(expr UnaryExpr) (Int, error) {
+	num, err := Eval(expr.Value)
+	if err != nil {
+		return 0, err
+	}
+
+	switch expr.Op {
+	case OpNOT:
+		return Int(^int64(num)), nil
+	}
+
+	return 0, fmt.Errorf("invalid unary expr: %s", expr.Op)
+}
+ 
+func evalBinExpr(expr BinExpr) (Int, error) {
+	var lhs, rhs Int
+	var err error
 	if expr.Lhs.Type() != NodeInt {
-		lhs, err = Eval(expr.Lhs.(Expr))
+		lhs, err = Eval(expr.Lhs)
 		if err != nil {
 			return 0, err
 		}
@@ -27,7 +47,7 @@ func Eval(n Node) (Int, error) {
 	}
 
 	if expr.Rhs.Type() != NodeInt {
-		rhs, err = Eval(expr.Rhs.(Expr))
+		rhs, err = Eval(expr.Rhs)
 		if err != nil {
 			return 0, err
 		}

--- a/infix/eval.go
+++ b/infix/eval.go
@@ -1,16 +1,16 @@
 package infix	
 
-func Eval(tree Expr) Int {
+func Eval(tree *Expr) Int {
 	var lhs, rhs Int
 
 	if tree.Lhs.Type() != NodeInt {
-		lhs = Eval(tree.Lhs.(Expr))
+		lhs = Eval(tree.Lhs.(*Expr))
 	} else {
 		lhs = tree.Lhs.(Int)
 	}
 
 	if tree.Rhs.Type() != NodeInt {
-		rhs = Eval(tree.Rhs.(Expr))
+		rhs = Eval(tree.Rhs.(*Expr))
 	} else {
 		rhs = tree.Rhs.(Int)
 	}

--- a/infix/eval.go
+++ b/infix/eval.go
@@ -37,8 +37,6 @@ func Eval(n Node) (Int, error) {
 		rhs = expr.Rhs.(Int)
 	}
 
-	fmt.Printf("Evaluating: %d %s %d\n", lhs, expr.Op, rhs)
-
 	var ret Int
 	switch expr.Op {
 	case OpAND:

--- a/infix/eval.go
+++ b/infix/eval.go
@@ -1,0 +1,26 @@
+package infix	
+
+func Eval(tree Expr) Int {
+	var lhs, rhs Int
+
+	if tree.Lhs.Type() != NodeInt {
+		lhs = Eval(tree.Lhs.(Expr))
+	} else {
+		lhs = tree.Lhs.(Int)
+	}
+
+	if tree.Rhs.Type() != NodeInt {
+		rhs = Eval(tree.Rhs.(Expr))
+	} else {
+		rhs = tree.Rhs.(Int)
+	}
+
+	var ret Int
+	switch tree.Op {
+	case OpAND:
+		ret = lhs & rhs
+	case OpOR:
+		ret = lhs | rhs
+	}
+	return ret
+}

--- a/infix/eval.go
+++ b/infix/eval.go
@@ -1,26 +1,50 @@
 package infix	
 
-func Eval(tree *Expr) Int {
-	var lhs, rhs Int
+import (
+	"fmt"
+)
 
-	if tree.Lhs.Type() != NodeInt {
-		lhs = Eval(tree.Lhs.(*Expr))
-	} else {
-		lhs = tree.Lhs.(Int)
+func Eval(n Node) (Int, error) {
+	var (
+		lhs, rhs Int
+		err error
+	)
+
+	if n.Type() == NodeInt {
+		return n.(Int), nil
 	}
 
-	if tree.Rhs.Type() != NodeInt {
-		rhs = Eval(tree.Rhs.(*Expr))
-	} else {
-		rhs = tree.Rhs.(Int)
+	if n.Type() != NodeExpr {
+		return 0, fmt.Errorf("unexpected %s", n)
 	}
+
+	expr := n.(*Expr)
+	if expr.Lhs.Type() != NodeInt {
+		lhs, err = Eval(expr.Lhs.(*Expr))
+		if err != nil {
+			return 0, err
+		}
+	} else {
+		lhs = expr.Lhs.(Int)
+	}
+
+	if expr.Rhs.Type() != NodeInt {
+		rhs, err = Eval(expr.Rhs.(*Expr))
+		if err != nil {
+			return 0, err
+		}
+	} else {
+		rhs = expr.Rhs.(Int)
+	}
+
+	fmt.Printf("Evaluating: %d %s %d\n", lhs, expr.Op, rhs)
 
 	var ret Int
-	switch tree.Op {
+	switch expr.Op {
 	case OpAND:
 		ret = lhs & rhs
 	case OpOR:
 		ret = lhs | rhs
 	}
-	return ret
+	return ret, nil
 }

--- a/infix/eval.go
+++ b/infix/eval.go
@@ -39,26 +39,24 @@ func evalUnaryExpr(expr UnaryExpr) (Int, error) {
 
 	return 0, fmt.Errorf("invalid unary expr: %s", expr.Op)
 }
- 
-func evalBinExpr(expr BinExpr) (Int, error) {
-	var lhs, rhs Int
-	var err error
-	if expr.Lhs.Type() != NodeInt {
-		lhs, err = Eval(expr.Lhs)
-		if err != nil {
-			return 0, err
-		}
-	} else {
-		lhs = expr.Lhs.(Int)
+
+func evalOperand(n Node) (Int, error) {
+	if n.Type() != NodeInt {
+		return Eval(n)
 	}
 
-	if expr.Rhs.Type() != NodeInt {
-		rhs, err = Eval(expr.Rhs)
-		if err != nil {
-			return 0, err
-		}
-	} else {
-		rhs = expr.Rhs.(Int)
+	return n.(Int), nil
+}
+ 
+func evalBinExpr(expr BinExpr) (Int, error) {
+	lhs, err := evalOperand(expr.Lhs)
+	if err != nil {
+		return 0, err
+	}
+	
+	rhs, err := evalOperand(expr.Rhs)
+	if err != nil {
+		return 0, err
 	}
 
 	var ret Int
@@ -72,7 +70,7 @@ func evalBinExpr(expr BinExpr) (Int, error) {
 	case OpSHR:
 		ret = lhs >> uint(rhs)
 	default:
-		return 0, fmt.Errorf("invalid op (%v)", expr.Op)
+		return 0	, fmt.Errorf("invalid op (%v)", expr.Op)
 	}
 	return ret, nil
 }

--- a/infix/eval.go
+++ b/infix/eval.go
@@ -4,20 +4,26 @@ import (
 	"fmt"
 )
 
+func Exec(code string) (Int, error) {
+	n, err := Parse(code)
+	if err != nil {
+		return 0, err
+	}
+	return Eval(n)
+}
+
 func Eval(n Node) (Int, error) {
-	if n.Type() == NodeInt {
+	switch n.Type() {
+	case NodeInt:
 		return n.(Int), nil
-	}
-
-	if n.Type() == NodeUnaryExpr {
+	case NodeUnaryExpr:
 		return evalUnaryExpr(n.(UnaryExpr))
+	case NodeBinExpr:
+		return evalBinExpr(n.(BinExpr))
 	}
 
-	if n.Type() != NodeBinExpr {
-		return 0, fmt.Errorf("unexpected %s", n)
-	}
 
-	return evalBinExpr(n.(BinExpr))
+	return 0, fmt.Errorf("unexpected %s", n) 
 }
 
 func evalUnaryExpr(expr UnaryExpr) (Int, error) {
@@ -65,6 +71,8 @@ func evalBinExpr(expr BinExpr) (Int, error) {
 		ret = lhs << uint(rhs)
 	case OpSHR:
 		ret = lhs >> uint(rhs)
+	default:
+		return 0, fmt.Errorf("invalid op (%v)", expr.Op)
 	}
 	return ret, nil
 }

--- a/infix/eval.go
+++ b/infix/eval.go
@@ -43,6 +43,10 @@ func Eval(n Node) (Int, error) {
 		ret = lhs & rhs
 	case OpOR:
 		ret = lhs | rhs
+	case OpSHL:
+		ret = lhs << uint(rhs)
+	case OpSHR:
+		ret = lhs >> uint(rhs)
 	}
 	return ret, nil
 }

--- a/infix/eval_test.go
+++ b/infix/eval_test.go
@@ -1,4 +1,4 @@
-package main
+package infix
 
 import (
 	"fmt"

--- a/infix/eval_test.go
+++ b/infix/eval_test.go
@@ -8,10 +8,13 @@ import (
 var format = fmt.Sprintf
 
 func desc(n Node, res Int) string {
-	if n.Type() == NodeExpr {
-		a := n.(Expr)
+	if n.Type() == NodeBinExpr {
+		a := n.(BinExpr)
 		return format("%s %s %s = %s",
 			a.Lhs, a.Rhs, a.Op, res)
+	} else if n.Type() == NodeUnaryExpr {
+		a := n.(UnaryExpr)
+		return format("%s%s", a.Op, a.Value)
 	}
 
 	a := n.(Int)
@@ -24,7 +27,7 @@ func TestEval(t *testing.T) {
 		res  Int
 	}{
 		{
-			expr: Expr{
+			expr: BinExpr{
 				Op:  OpAND,
 				Lhs: Int(0),
 				Rhs: Int(0),
@@ -32,7 +35,7 @@ func TestEval(t *testing.T) {
 			res: 0,
 		},
 		{
-			expr: Expr{
+			expr: BinExpr{
 				Op:  OpAND,
 				Lhs: Int(0),
 				Rhs: Int(1),
@@ -40,7 +43,7 @@ func TestEval(t *testing.T) {
 			res: 0,
 		},
 		{
-			expr: Expr{
+			expr: BinExpr{
 				Op:  OpAND,
 				Lhs: Int(1),
 				Rhs: Int(1),
@@ -48,7 +51,7 @@ func TestEval(t *testing.T) {
 			res: 1,
 		},
 		{
-			expr: Expr{
+			expr: BinExpr{
 				Op:  OpAND,
 				Lhs: Int(0xffff0000),
 				Rhs: Int(0x0000ffff),
@@ -56,7 +59,7 @@ func TestEval(t *testing.T) {
 			res: 0,
 		},
 		{
-			expr: Expr{
+			expr: BinExpr{
 				Op:  OpOR,
 				Lhs: Int(0xffff0000),
 				Rhs: Int(0x0000ffff),
@@ -66,9 +69,9 @@ func TestEval(t *testing.T) {
 
 		// groups
 		{
-			expr: Expr{
+			expr: BinExpr{
 				Op: OpAND,
-				Lhs: Expr{
+				Lhs: BinExpr{
 					Op:  OpOR,
 					Lhs: Int(0xffff0000),
 					Rhs: Int(0x0000ffff),
@@ -78,20 +81,27 @@ func TestEval(t *testing.T) {
 			res: 0x000000ff,
 		},
 		{
-			expr: Expr{
+			expr: BinExpr{
 				Op: OpOR,
-				Lhs: Expr{
+				Lhs: BinExpr{
 					Op:  OpOR,
 					Lhs: Int(0x000000ff),
 					Rhs: Int(0xff000000),
 				},
-				Rhs: Expr{
+				Rhs: BinExpr{
 					Op:  OpOR,
 					Lhs: Int(0x00ff0000),
 					Rhs: Int(0x0000ff00),
 				},
 			},
 			res: 0xffffffff,
+		},
+		{
+			expr: UnaryExpr{
+				Op: OpNOT,
+				Value: Int(7),
+			},
+			res: -8,
 		},
 	} {
 		tc := tc

--- a/infix/eval_test.go
+++ b/infix/eval_test.go
@@ -21,6 +21,59 @@ func desc(n Node, res Int) string {
 	return format("%d", a)
 }
 
+func TestEvalGrammar(t *testing.T) {
+	for _, tc := range []struct {
+		code string
+		res  Int
+	}{
+		{
+			code: "0",
+			res:  0,
+		},
+		{
+			code: "0|1",
+			res:  1,
+		},
+		{
+			code: "0|1|2",
+			res:  3,
+		},
+		{
+			code: "0|1|2|3",
+			// 00000000
+			// 00000001
+			// 00000010
+			// 00000011
+			res: 3,
+		},
+		{
+			code: "0|1|2|3|4",
+			res:  7,
+		},
+		{
+			code: "0&1",
+			res:  0,
+		},
+		{
+			code: "7&3",
+			res:  3,
+		},
+		{
+			code: "1|2&1",
+			res:  1,
+		},
+	} {
+		got, err := Exec(tc.code)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got != tc.res {
+			t.Fatalf("got(%s) != expected(%s)", got, tc.res)
+		}
+	}
+}
+
 func TestEval(t *testing.T) {
 	for _, tc := range []struct {
 		expr Node
@@ -98,7 +151,7 @@ func TestEval(t *testing.T) {
 		},
 		{
 			expr: UnaryExpr{
-				Op: OpNOT,
+				Op:    OpNOT,
 				Value: Int(7),
 			},
 			res: -8,

--- a/infix/eval_test.go
+++ b/infix/eval_test.go
@@ -76,6 +76,26 @@ func TestEvalGrammar(t *testing.T) {
 			code: "a | 1",
 			res: 1,
 		},
+		{
+			code: "a = 0xff",
+			res: 0xff,
+		},
+		{
+			code: "a&1",
+			res: 1,
+		},
+		{
+			code: "(a&0)|1",
+			res: 1,
+		},
+		{
+			code: "a&(a&0)",
+			res: 0,
+		},
+		{
+			code: "1<<10|0xff",
+			res: 0x4ff,
+		},
 	} {
 		
 		got, err := interp.Exec(tc.code)

--- a/infix/eval_test.go
+++ b/infix/eval_test.go
@@ -9,7 +9,7 @@ var format = fmt.Sprintf
 
 func desc(n Node, res Int) string {
 	if n.Type() == NodeExpr {
-		a := n.(*Expr)
+		a := n.(Expr)
 		return format("%s %s %s = %s",
 			a.Lhs, a.Rhs, a.Op, res)
 	}
@@ -24,7 +24,7 @@ func TestEval(t *testing.T) {
 		res  Int
 	}{
 		{
-			expr: &Expr{
+			expr: Expr{
 				Op:  OpAND,
 				Lhs: Int(0),
 				Rhs: Int(0),
@@ -32,7 +32,7 @@ func TestEval(t *testing.T) {
 			res: 0,
 		},
 		{
-			expr: &Expr{
+			expr: Expr{
 				Op:  OpAND,
 				Lhs: Int(0),
 				Rhs: Int(1),
@@ -40,7 +40,7 @@ func TestEval(t *testing.T) {
 			res: 0,
 		},
 		{
-			expr: &Expr{
+			expr: Expr{
 				Op:  OpAND,
 				Lhs: Int(1),
 				Rhs: Int(1),
@@ -48,7 +48,7 @@ func TestEval(t *testing.T) {
 			res: 1,
 		},
 		{
-			expr: &Expr{
+			expr: Expr{
 				Op:  OpAND,
 				Lhs: Int(0xffff0000),
 				Rhs: Int(0x0000ffff),
@@ -56,7 +56,7 @@ func TestEval(t *testing.T) {
 			res: 0,
 		},
 		{
-			expr: &Expr{
+			expr: Expr{
 				Op:  OpOR,
 				Lhs: Int(0xffff0000),
 				Rhs: Int(0x0000ffff),
@@ -66,9 +66,9 @@ func TestEval(t *testing.T) {
 
 		// groups
 		{
-			expr: &Expr{
+			expr: Expr{
 				Op: OpAND,
-				Lhs: &Expr{
+				Lhs: Expr{
 					Op:  OpOR,
 					Lhs: Int(0xffff0000),
 					Rhs: Int(0x0000ffff),
@@ -78,14 +78,14 @@ func TestEval(t *testing.T) {
 			res: 0x000000ff,
 		},
 		{
-			expr: &Expr{
+			expr: Expr{
 				Op: OpOR,
-				Lhs: &Expr{
+				Lhs: Expr{
 					Op:  OpOR,
 					Lhs: Int(0x000000ff),
 					Rhs: Int(0xff000000),
 				},
-				Rhs: &Expr{
+				Rhs: Expr{
 					Op:  OpOR,
 					Lhs: Int(0x00ff0000),
 					Rhs: Int(0x0000ff00),

--- a/infix/eval_test.go
+++ b/infix/eval_test.go
@@ -96,6 +96,14 @@ func TestEvalGrammar(t *testing.T) {
 			code: "1<<10|0xff",
 			res: 0x4ff,
 		},
+		{
+			code: "b = 0b01010101",
+			res: 0x55,
+		},
+		{
+			code: "a&b",
+			res: 85,
+		},
 	} {
 		
 		got, err := interp.Exec(tc.code)

--- a/infix/eval_test.go
+++ b/infix/eval_test.go
@@ -22,6 +22,8 @@ func desc(n Node, res Int) string {
 }
 
 func TestEvalGrammar(t *testing.T) {
+	interp := NewInterp()
+
 	for _, tc := range []struct {
 		code string
 		res  Int
@@ -62,8 +64,21 @@ func TestEvalGrammar(t *testing.T) {
 			code: "1|2&1",
 			res:  1,
 		},
+		{
+			code: "a = 0",
+			res: 0,
+		},
+		{
+			code: "b = a",
+			res: 0,
+		},
+		{
+			code: "a | 1",
+			res: 1,
+		},
 	} {
-		got, err := Exec(tc.code)
+		
+		got, err := interp.Exec(tc.code)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -159,7 +174,8 @@ func TestEval(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(desc(tc.expr, tc.res), func(t *testing.T) {
-			got, err := Eval(tc.expr)
+			interp := NewInterp()
+			got, err := interp.Eval(tc.expr)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/infix/lexer.go
+++ b/infix/lexer.go
@@ -138,6 +138,14 @@ func (l *lexer) acceptRunfn(fn func(r rune) bool) {
 func lexStart(l *lexer) stateFn {
 	r := l.next()
 	switch {
+	case isIdentBegin(r):
+		l.acceptRunfn(func (r rune) bool {
+			return unicode.IsLetter(r) ||
+					unicode.IsDigit(r) ||
+					r == '_'
+		})
+		l.emit(Ident)
+		return lexStart		
 	case unicode.IsSpace(r):
 		l.acceptRunfn(unicode.IsSpace)
 		l.ignore()
@@ -178,6 +186,9 @@ func lexStart(l *lexer) stateFn {
 		return lexStart
 	case r == ')':
 		l.emit(RParen)
+		return lexStart
+	case r == '=':
+		l.emit(Equal)
 		return lexStart
 	default:
 		return l.errorf("Unexpected %q at %d", r, l.pos)
@@ -222,4 +233,9 @@ func lexNumber(l *lexer) stateFn {
 
 func isAlphaNumeric(r rune) bool {
 	return unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// isIdentBegin tells if r could be the first rune of an ident.
+func isIdentBegin(r rune) bool {
+	return unicode.IsLetter(r) || r == '_'
 }

--- a/infix/lexer.go
+++ b/infix/lexer.go
@@ -3,12 +3,12 @@ package infix
 import (
 	"fmt"
 	"strings"
-	"unicode/utf8"
 	"unicode"
+	"unicode/utf8"
 )
 
 type (
-	Lexer struct {
+	lexer struct {
 		input  string // expression being lex'ed
 		start  int    // start position of token
 		pos    int    // pos in the input
@@ -16,7 +16,7 @@ type (
 		tokens chan Tokval
 	}
 
-	stateFn func(*Lexer) stateFn
+	stateFn func(*lexer) stateFn
 
 	// Tokval is the token type + value
 	Tokval struct {
@@ -25,14 +25,18 @@ type (
 	}
 )
 
+// eof mimics the EOF but for the input string.
+// The name isn't eoi to avoid confusion.
 const eof = -1
 
 func (t Tokval) String() string {
 	return fmt.Sprintf("Token(%s, %s)", t.T, t.V)
 }
 
+// Lex creates a concurrent lexer and returns a
+// channel of tokens processed from input.
 func Lex(input string) chan Tokval {
-	l := &Lexer{
+	l := &lexer{
 		input:  input,
 		tokens: make(chan Tokval),
 	}
@@ -41,14 +45,16 @@ func Lex(input string) chan Tokval {
 	return l.tokens
 }
 
-func (l *Lexer) run() {
+// run the state machine
+func (l *lexer) run() {
 	for state := lexStart; state != nil; {
 		state = state(l)
 	}
 	close(l.tokens)
 }
 
-func (l *Lexer) emit(tok Token) {
+// emit a token.
+func (l *lexer) emit(tok Token) {
 	l.tokens <- Tokval{
 		T: tok,
 		V: l.input[l.start:l.pos],
@@ -56,24 +62,31 @@ func (l *Lexer) emit(tok Token) {
 	l.start = l.pos
 }
 
-func (l *Lexer) errorf(msg string, args ...interface{}) {
+// errorf emits an illegal token. This token carries
+// the lexer error.
+func (l *lexer) errorf(msg string, args ...interface{}) stateFn {
 	l.tokens <- Tokval{
 		T: Illegal,
 		V: fmt.Sprintf(msg, args...),
 	}
-	l.start = len(l.input)
-	l.pos = l.start
+	return nil
 }
 
-func (l *Lexer) current() rune {
-	if l.pos >= len(l.input) {
+// peek looks for the next rune from the input
+// but do not increases the cursor.
+// It returns eof when reaches the end of input.
+func (l *lexer) peek() rune {
+	r := l.next()
+	if r == eof {
 		return eof
 	}
-	r, _ := utf8.DecodeRuneInString(l.input[l.pos:])
+	l.backup()
 	return r
 }
 
-func (l *Lexer) next() (r rune) {
+// next returns the next rune from input or
+// eof if reached end of input.
+func (l *lexer) next() (r rune) {
 	if l.pos >= len(l.input) {
 		// zeroes the width to simplify handling at
 		// end of input. Some functions like acceptRun*
@@ -88,22 +101,29 @@ func (l *Lexer) next() (r rune) {
 	return r
 }
 
-func (l *Lexer) backup() {
+// backup rollback one rune.
+func (l *lexer) backup() {
 	l.pos -= l.width
 }
 
-func (l *Lexer) ignore() {
+// ignore bytes processed since last token.
+func (l *lexer) ignore() {
 	l.start = l.pos
 }
 
-func (l *Lexer) acceptRun(valid string) {
+// accept checks if next is in the valid string.
+func (l *lexer) accept(valid string) bool {
+	return strings.IndexRune(valid, l.peek()) != -1
+}
+
+func (l *lexer) acceptRun(valid string) {
 	for strings.IndexRune(valid, l.next()) >= 0 {
 	}
 
 	l.backup()
 }
 
-func (l *Lexer) acceptRunfn(fn func (r rune) bool) {
+func (l *lexer) acceptRunfn(fn func(r rune) bool) {
 	for fn(l.next()) {
 
 	}
@@ -111,24 +131,37 @@ func (l *Lexer) acceptRunfn(fn func (r rune) bool) {
 	l.backup()
 }
 
-func lexStart(l *Lexer) stateFn {
+func lexStart(l *lexer) stateFn {
 	r := l.next()
 	switch {
-	case unicode.IsSpace(r):	
+	case unicode.IsSpace(r):
 		l.acceptRunfn(unicode.IsSpace)
 		l.ignore()
 		return lexStart
 	case r == eof:
 		return nil
 	case r >= '0' && r <= '9':
-		l.acceptRun("0123456789")
-		l.emit(Number)
-		return lexStart
+		l.backup()
+		return lexNumber
 	case r == '|':
 		l.emit(OR)
 		return lexStart
 	case r == '&':
 		l.emit(AND)
+		return lexStart
+	case r == '<':
+		next := l.next()
+		if next != '<' {
+			return l.errorf("unexpected %q", next)
+		}
+		l.emit(SHL)
+		return lexStart
+	case r == '>':
+		next := l.next()
+		if next != '>' {
+			return l.errorf("unexpected %q", next)
+		}
+		l.emit(SHR)
 		return lexStart
 	case r == '(':
 		l.emit(LParen)
@@ -137,7 +170,46 @@ func lexStart(l *Lexer) stateFn {
 		l.emit(RParen)
 		return lexStart
 	default:
-		l.errorf("Unexpected %q at %d", r, l.pos)
+		return l.errorf("Unexpected %q at %d", r, l.pos)
 	}
 	return nil
+}
+
+// lexer of dec, hex and bin numbers.
+func lexNumber(l *lexer) stateFn {
+	r := l.next()
+	next := l.peek()
+	if r == '0' && next == 'b' {
+		// 0bnnnnnnnn	
+		l.next()
+		digits := "01"
+		if !l.accept(digits) {
+			return l.errorf("malformed binary number")
+		}
+
+		l.acceptRun(digits)
+	} else if r == '0' && next == 'x' {
+		// 0xnnnnnnnn
+		l.next()
+		digits := "0123456789abcdef"
+		if !l.accept(digits) {
+			return l.errorf("malformed hex number")
+		}
+
+		l.acceptRun(digits)
+	} else {
+		// decimal
+		l.acceptRun("0123456789")
+	}
+
+	if isAlphaNumeric(l.peek()) {
+		return l.errorf("malformed number")
+	}
+
+	l.emit(Number)
+	return lexStart
+}
+
+func isAlphaNumeric(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
 }

--- a/infix/lexer.go
+++ b/infix/lexer.go
@@ -36,7 +36,7 @@ func (t Tokval) String() string {
 
 // Lex creates a concurrent lexer and returns a
 // channel of tokens processed from input.
-func Lex(input string) chan Tokval {
+func Lex(input string) <-chan Tokval {
 	l := &lexer{
 		input:  input,
 		tokens: make(chan Tokval),

--- a/infix/lexer.go
+++ b/infix/lexer.go
@@ -142,7 +142,7 @@ func lexStart(l *lexer) stateFn {
 		l.acceptRunfn(unicode.IsSpace)
 		l.ignore()
 		return lexStart
-	case r == eof:
+	case r == eof: 
 		return nil
 	case r >= '0' && r <= '9':
 		l.backup()
@@ -152,6 +152,12 @@ func lexStart(l *lexer) stateFn {
 		return lexStart
 	case r == '&':
 		l.emit(AND)
+		return lexStart
+	case r == '^':
+		l.emit(XOR)
+		return lexStart
+	case r == '~':
+		l.emit(NOT)
 		return lexStart
 	case r == '<':
 		next := l.next()

--- a/infix/lexer.go
+++ b/infix/lexer.go
@@ -1,0 +1,114 @@
+package infix
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+type (
+	Lexer struct {
+		input  string // expression being lex'ed
+		start  int    // start position of token
+		pos    int    // pos in the input
+		width  int    // width of last rune
+		tokens chan Tokval
+	}
+
+	stateFn func(*Lexer) stateFn
+
+	// Tokval is the token type + value
+	Tokval struct {
+		T Token
+		V string
+	}
+)
+
+const eof = -1
+
+func Lex(input string) chan Tokval {
+	l := &Lexer{
+		input:  input,
+		tokens: make(chan Tokval),
+	}
+
+	go l.run()
+	return l.tokens
+}
+
+func (l *Lexer) run() {
+	for state := lexStart; state != nil; {
+		state = state(l)
+	}
+	close(l.tokens)
+}
+
+func (l *Lexer) emit(tok Token) {
+	l.tokens <- Tokval{
+		T: tok,
+		V: l.input[l.start:l.pos],
+	}
+	l.start = l.pos
+}
+
+func (l *Lexer) errorf(msg string, args ...interface{}) {
+	l.tokens <- Tokval{
+		T: Illegal,
+		V: fmt.Sprintf(msg, args...),
+	}
+	l.start = len(l.input)
+	l.pos = l.start
+}
+
+func (l *Lexer) current() rune {
+	if l.pos >= len(l.input) {
+		return eof
+	}
+	r, _ := utf8.DecodeRuneInString(l.input[l.pos:])
+	return r
+}
+
+func (l *Lexer) next() (r rune) {
+	if l.pos >= len(l.input) {
+		return eof
+	}
+	r, l.width = utf8.DecodeRuneInString(l.input[l.pos:])
+	l.pos += l.width
+	return r
+}
+
+func (l *Lexer) backup() {
+	l.pos -= l.width
+}
+
+func (l *Lexer) acceptRun(valid string) {
+	for strings.IndexRune(valid, l.next()) >= 0 {
+	
+	}
+
+	// no rewind in case of end of input
+	if l.current() != eof {
+		l.backup()
+	}
+}
+
+func lexStart(l *Lexer) stateFn {
+	r := l.next()
+	switch {
+	case r == eof:
+		return nil
+	case '0' <= r && r <= '9':
+		l.acceptRun("xb0123456789")
+		l.emit(Number)
+		return lexStart
+	case r == '|':
+		l.emit(OR)
+		return lexStart
+	case r == '&':
+		l.emit(AND)
+		return lexStart
+	default:
+		l.errorf("Unexpected %q at %d", r, l.pos)
+	}
+	return nil
+}

--- a/infix/lexer.go
+++ b/infix/lexer.go
@@ -116,6 +116,7 @@ func (l *lexer) accept(valid string) bool {
 	return strings.IndexRune(valid, l.peek()) != -1
 }
 
+// acceptRun consumes next runes if valid.
 func (l *lexer) acceptRun(valid string) {
 	for strings.IndexRune(valid, l.next()) >= 0 {
 	}
@@ -123,6 +124,8 @@ func (l *lexer) acceptRun(valid string) {
 	l.backup()
 }
 
+// acceptRunfn is like acceptRun but uses fn as 
+// function comparator.
 func (l *lexer) acceptRunfn(fn func(r rune) bool) {
 	for fn(l.next()) {
 
@@ -131,6 +134,7 @@ func (l *lexer) acceptRunfn(fn func(r rune) bool) {
 	l.backup()
 }
 
+// lexStart is the start of state machine
 func lexStart(l *lexer) stateFn {
 	r := l.next()
 	switch {

--- a/infix/lexer_test.go
+++ b/infix/lexer_test.go
@@ -53,7 +53,6 @@ func TestLexer(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			in: "0&0|1",
 			out: []infix.Tokval{
@@ -76,6 +75,31 @@ func TestLexer(t *testing.T) {
 				{
 					T: infix.Number,
 					V: "1",
+				},
+			},
+		},
+		{
+			in: "(0&0)",
+			out: []infix.Tokval{
+				{
+					T: infix.LParen,
+					V: "(",
+				},
+				{
+					T: infix.Number,
+					V: "0",
+				},
+				{
+					T: infix.AND,
+					V: "&",
+				},
+				{
+					T: infix.Number,
+					V: "0",
+				},
+				{
+					T: infix.RParen,
+					V: ")",
 				},
 			},
 		},

--- a/infix/lexer_test.go
+++ b/infix/lexer_test.go
@@ -83,6 +83,8 @@ func TestLexer(t *testing.T) {
 		tc := tc
 		got := consume(infix.Lex(tc.in))
 		if len(got) != len(tc.out) {
+			t.Logf("test data: %v", tc.in)
+			t.Logf("got: %v", got)
 			t.Fatalf("expect %d elems but got %d",
 				len(tc.out), len(got))
 		}

--- a/infix/lexer_test.go
+++ b/infix/lexer_test.go
@@ -5,6 +5,11 @@ import (
 	"testing"
 )
 
+type testcase struct {
+	in  string
+	out []infix.Tokval
+}
+
 func consume(tokens chan infix.Tokval) []infix.Tokval {
 	var toks []infix.Tokval
 	for tok := range tokens {
@@ -13,11 +18,30 @@ func consume(tokens chan infix.Tokval) []infix.Tokval {
 	return toks
 }
 
+func test(t *testing.T, tc testcase) {
+	t.Helper()
+	got := consume(infix.Lex(tc.in))
+	if len(got) != len(tc.out) {
+		t.Logf("test data: %v", tc.in)
+		t.Logf("got: %v", got)
+		t.Fatalf("expect %d elems but got %d",
+			len(tc.out), len(got))
+	}
+
+	for i := 0; i < len(tc.out); i++ {
+		e := tc.out[i]
+		g := got[i]
+		if e.T != g.T {
+			t.Fatalf("tok differs: %v != %v", e, g)
+		}
+		if e.V != g.V {
+			t.Fatalf("tok differs: %s != %s", e.V, g.V)
+		}
+	}
+}
+
 func TestLexer(t *testing.T) {
-	for _, tc := range []struct {
-		in  string
-		out []infix.Tokval
-	}{
+	for _, tc := range []testcase{
 		{
 			in: "0",
 			out: []infix.Tokval{
@@ -103,25 +127,113 @@ func TestLexer(t *testing.T) {
 				},
 			},
 		},
+		{
+			in: "0xf",
+			out: []infix.Tokval{
+				{
+					T: infix.Number,
+					V: "0xf",
+				},
+			},
+		},
+		{
+			in: "(1>>2)",
+			out: []infix.Tokval{
+				{
+					T: infix.LParen,
+					V: "(",
+				},
+				{
+					T: infix.Number,
+					V: "1",
+				},
+				{
+					T: infix.RShift,
+					V: ">>",
+				},
+				{
+					T: infix.Number,
+					V: "2",
+				},
+				{
+					T: infix.RParen,
+					V: ")",
+				},
+			},
+		},
 	} {
 		tc := tc
-		got := consume(infix.Lex(tc.in))
-		if len(got) != len(tc.out) {
-			t.Logf("test data: %v", tc.in)
-			t.Logf("got: %v", got)
-			t.Fatalf("expect %d elems but got %d",
-				len(tc.out), len(got))
-		}
+		test(t, tc)
+	}
+}
 
-		for i := 0; i < len(tc.out); i++ {
-			e := tc.out[i]
-			g := got[i]
-			if e.T != g.T {
-				t.Fatalf("tok differs: %v != %v", e, g)
-			}
-			if e.V != g.V {
-				t.Fatalf("tok differs: %s != %s", e.V, g.V)
-			}
-		}
+func TestLexerNumbers(t *testing.T) {
+	for _, tc := range []testcase{
+		{
+			in: "01",
+			out: []infix.Tokval{
+				{
+					T: infix.Number,
+					V: "01",
+				},
+			},
+		},
+		{
+			in: "97497239472938",
+			out: []infix.Tokval{
+				{
+					T: infix.Number,
+					V: "97497239472938",
+				},
+			},
+		},
+		{
+			in: "0b",
+			out: []infix.Tokval{
+				{
+					T: infix.Illegal,
+					V: "malformed binary number",
+				},
+			},
+		},
+		{
+			in: "0bf",
+			out: []infix.Tokval{
+				{
+					T: infix.Illegal,
+					V: "malformed binary number",
+				},
+			},
+		},
+		{
+			in: "0b111112",
+			out: []infix.Tokval{
+				{
+					T: infix.Illegal,
+					V: "malformed number",
+				},
+			},
+		},
+		{
+			in: "0xffg",
+			out: []infix.Tokval{
+				{
+					T: infix.Illegal,
+					V: "malformed number",
+				},
+			},
+		},
+		{
+			in: "0b11111111",
+			out: []infix.Tokval{
+				{
+					T: infix.Number,
+					V: "0b11111111",
+				},
+			},
+		},
+	} {
+		tc := tc
+		test(t, tc)
 	}
 }

--- a/infix/lexer_test.go
+++ b/infix/lexer_test.go
@@ -148,7 +148,7 @@ func TestLexer(t *testing.T) {
 					V: "1",
 				},
 				{
-					T: infix.RShift,
+					T: infix.SHR,
 					V: ">>",
 				},
 				{

--- a/infix/lexer_test.go
+++ b/infix/lexer_test.go
@@ -178,6 +178,66 @@ func TestLexer(t *testing.T) {
 				},
 			},
 		},
+		{
+			in: "a = 0",
+			out: []infix.Tokval{
+				{
+					T: infix.Ident,
+					V: "a",
+				},
+				{
+					T: infix.Equal,
+					V: "=",
+				},
+				{
+					T: infix.Number,
+					V: "0",
+				},
+			},
+		},
+		{
+			in: "aa = aa",
+			out: []infix.Tokval{
+				{
+					T: infix.Ident,
+					V: "aa",
+				},
+				{
+					T: infix.Equal,
+					V: "=",
+				},
+				{
+					T: infix.Ident,
+					V: "aa",
+				},
+			},
+		},
+		{
+			in: "_a = 0b10000",
+			out: []infix.Tokval{
+				{
+					T: infix.Ident,
+					V: "_a",
+				},
+				{
+					T: infix.Equal,
+					V: "=",
+				},
+				{
+					T: infix.Number,
+					V: "0b10000",
+				},
+			},
+		},
+		{
+			in: "1invalid = 0b10000",
+			out: []infix.Tokval{
+				{
+					T: infix.Illegal,
+					V: "malformed number",
+				},
+			},
+		},
 	} {
 		tc := tc
 		test(t, tc)

--- a/infix/lexer_test.go
+++ b/infix/lexer_test.go
@@ -68,8 +68,25 @@ func TestLexer(t *testing.T) {
 					V: "0",
 				},
 				{
-					T: infix.AND,
+					T: infix.AND, 
 					V: "&",
+				},
+				{
+					T: infix.Number,
+					V: "0",
+				},
+			},
+		},
+		{
+			in: "0^0",
+			out: []infix.Tokval{
+				{
+					T: infix.Number,
+					V: "0",
+				},
+				{
+					T: infix.XOR,
+					V: "^",
 				},
 				{
 					T: infix.Number,

--- a/infix/lexer_test.go
+++ b/infix/lexer_test.go
@@ -31,11 +31,11 @@ func test(t *testing.T, tc testcase) {
 	for i := 0; i < len(tc.out); i++ {
 		e := tc.out[i]
 		g := got[i]
-		if e.T != g.T {
+		if e.Type != g.Type {
 			t.Fatalf("tok differs: %v != %v", e, g)
 		}
-		if e.V != g.V {
-			t.Fatalf("tok differs: %s != %s", e.V, g.V)
+		if e.Value != g.Value {
+			t.Fatalf("tok differs: %s != %s", e.Value, g.Value)
 		}
 	}
 }
@@ -46,8 +46,8 @@ func TestLexer(t *testing.T) {
 			in: "0",
 			out: []infix.Tokval{
 				{
-					T: infix.Number,
-					V: "0",
+					Type:  infix.Number,
+					Value: "0",
 				},
 			},
 		},
@@ -55,8 +55,8 @@ func TestLexer(t *testing.T) {
 			in: "0123456789",
 			out: []infix.Tokval{
 				{
-					T: infix.Number,
-					V: "0123456789",
+					Type:  infix.Number,
+					Value: "0123456789",
 				},
 			},
 		},
@@ -64,16 +64,16 @@ func TestLexer(t *testing.T) {
 			in: "0&0",
 			out: []infix.Tokval{
 				{
-					T: infix.Number,
-					V: "0",
+					Type:  infix.Number,
+					Value: "0",
 				},
 				{
-					T: infix.AND, 
-					V: "&",
+					Type:  infix.AND,
+					Value: "&",
 				},
 				{
-					T: infix.Number,
-					V: "0",
+					Type:  infix.Number,
+					Value: "0",
 				},
 			},
 		},
@@ -81,16 +81,16 @@ func TestLexer(t *testing.T) {
 			in: "0^0",
 			out: []infix.Tokval{
 				{
-					T: infix.Number,
-					V: "0",
+					Type:  infix.Number,
+					Value: "0",
 				},
 				{
-					T: infix.XOR,
-					V: "^",
+					Type:  infix.XOR,
+					Value: "^",
 				},
 				{
-					T: infix.Number,
-					V: "0",
+					Type:  infix.Number,
+					Value: "0",
 				},
 			},
 		},
@@ -98,24 +98,24 @@ func TestLexer(t *testing.T) {
 			in: "0&0|1",
 			out: []infix.Tokval{
 				{
-					T: infix.Number,
-					V: "0",
+					Type:  infix.Number,
+					Value: "0",
 				},
 				{
-					T: infix.AND,
-					V: "&",
+					Type:  infix.AND,
+					Value: "&",
 				},
 				{
-					T: infix.Number,
-					V: "0",
+					Type:  infix.Number,
+					Value: "0",
 				},
 				{
-					T: infix.OR,
-					V: "|",
+					Type:  infix.OR,
+					Value: "|",
 				},
 				{
-					T: infix.Number,
-					V: "1",
+					Type:  infix.Number,
+					Value: "1",
 				},
 			},
 		},
@@ -123,24 +123,24 @@ func TestLexer(t *testing.T) {
 			in: "(0&0)",
 			out: []infix.Tokval{
 				{
-					T: infix.LParen,
-					V: "(",
+					Type:  infix.LParen,
+					Value: "(",
 				},
 				{
-					T: infix.Number,
-					V: "0",
+					Type:  infix.Number,
+					Value: "0",
 				},
 				{
-					T: infix.AND,
-					V: "&",
+					Type:  infix.AND,
+					Value: "&",
 				},
 				{
-					T: infix.Number,
-					V: "0",
+					Type:  infix.Number,
+					Value: "0",
 				},
 				{
-					T: infix.RParen,
-					V: ")",
+					Type:  infix.RParen,
+					Value: ")",
 				},
 			},
 		},
@@ -148,8 +148,8 @@ func TestLexer(t *testing.T) {
 			in: "0xf",
 			out: []infix.Tokval{
 				{
-					T: infix.Number,
-					V: "0xf",
+					Type:  infix.Number,
+					Value: "0xf",
 				},
 			},
 		},
@@ -157,24 +157,24 @@ func TestLexer(t *testing.T) {
 			in: "(1>>2)",
 			out: []infix.Tokval{
 				{
-					T: infix.LParen,
-					V: "(",
+					Type:  infix.LParen,
+					Value: "(",
 				},
 				{
-					T: infix.Number,
-					V: "1",
+					Type:  infix.Number,
+					Value: "1",
 				},
 				{
-					T: infix.SHR,
-					V: ">>",
+					Type:  infix.SHR,
+					Value: ">>",
 				},
 				{
-					T: infix.Number,
-					V: "2",
+					Type:  infix.Number,
+					Value: "2",
 				},
 				{
-					T: infix.RParen,
-					V: ")",
+					Type:  infix.RParen,
+					Value: ")",
 				},
 			},
 		},
@@ -182,16 +182,16 @@ func TestLexer(t *testing.T) {
 			in: "a = 0",
 			out: []infix.Tokval{
 				{
-					T: infix.Ident,
-					V: "a",
+					Type:  infix.Ident,
+					Value: "a",
 				},
 				{
-					T: infix.Equal,
-					V: "=",
+					Type:  infix.Equal,
+					Value: "=",
 				},
 				{
-					T: infix.Number,
-					V: "0",
+					Type:  infix.Number,
+					Value: "0",
 				},
 			},
 		},
@@ -199,16 +199,16 @@ func TestLexer(t *testing.T) {
 			in: "aa = aa",
 			out: []infix.Tokval{
 				{
-					T: infix.Ident,
-					V: "aa",
+					Type:  infix.Ident,
+					Value: "aa",
 				},
 				{
-					T: infix.Equal,
-					V: "=",
+					Type:  infix.Equal,
+					Value: "=",
 				},
 				{
-					T: infix.Ident,
-					V: "aa",
+					Type:  infix.Ident,
+					Value: "aa",
 				},
 			},
 		},
@@ -216,16 +216,16 @@ func TestLexer(t *testing.T) {
 			in: "_a = 0b10000",
 			out: []infix.Tokval{
 				{
-					T: infix.Ident,
-					V: "_a",
+					Type:  infix.Ident,
+					Value: "_a",
 				},
 				{
-					T: infix.Equal,
-					V: "=",
+					Type:  infix.Equal,
+					Value: "=",
 				},
 				{
-					T: infix.Number,
-					V: "0b10000",
+					Type:  infix.Number,
+					Value: "0b10000",
 				},
 			},
 		},
@@ -233,8 +233,8 @@ func TestLexer(t *testing.T) {
 			in: "1invalid = 0b10000",
 			out: []infix.Tokval{
 				{
-					T: infix.Illegal,
-					V: "malformed number",
+					Type:  infix.Illegal,
+					Value: "malformed number",
 				},
 			},
 		},
@@ -250,8 +250,8 @@ func TestLexerNumbers(t *testing.T) {
 			in: "01",
 			out: []infix.Tokval{
 				{
-					T: infix.Number,
-					V: "01",
+					Type:  infix.Number,
+					Value: "01",
 				},
 			},
 		},
@@ -259,8 +259,8 @@ func TestLexerNumbers(t *testing.T) {
 			in: "97497239472938",
 			out: []infix.Tokval{
 				{
-					T: infix.Number,
-					V: "97497239472938",
+					Type:  infix.Number,
+					Value: "97497239472938",
 				},
 			},
 		},
@@ -268,8 +268,8 @@ func TestLexerNumbers(t *testing.T) {
 			in: "0b",
 			out: []infix.Tokval{
 				{
-					T: infix.Illegal,
-					V: "malformed binary number",
+					Type:  infix.Illegal,
+					Value: "malformed binary number",
 				},
 			},
 		},
@@ -277,8 +277,8 @@ func TestLexerNumbers(t *testing.T) {
 			in: "0bf",
 			out: []infix.Tokval{
 				{
-					T: infix.Illegal,
-					V: "malformed binary number",
+					Type:  infix.Illegal,
+					Value: "malformed binary number",
 				},
 			},
 		},
@@ -286,8 +286,8 @@ func TestLexerNumbers(t *testing.T) {
 			in: "0b111112",
 			out: []infix.Tokval{
 				{
-					T: infix.Illegal,
-					V: "malformed number",
+					Type:  infix.Illegal,
+					Value: "malformed number",
 				},
 			},
 		},
@@ -295,8 +295,8 @@ func TestLexerNumbers(t *testing.T) {
 			in: "0xffg",
 			out: []infix.Tokval{
 				{
-					T: infix.Illegal,
-					V: "malformed number",
+					Type:  infix.Illegal,
+					Value: "malformed number",
 				},
 			},
 		},
@@ -304,8 +304,8 @@ func TestLexerNumbers(t *testing.T) {
 			in: "0b11111111",
 			out: []infix.Tokval{
 				{
-					T: infix.Number,
-					V: "0b11111111",
+					Type:  infix.Number,
+					Value: "0b11111111",
 				},
 			},
 		},

--- a/infix/lexer_test.go
+++ b/infix/lexer_test.go
@@ -10,7 +10,7 @@ type testcase struct {
 	out []infix.Tokval
 }
 
-func consume(tokens chan infix.Tokval) []infix.Tokval {
+func consume(tokens <-chan infix.Tokval) []infix.Tokval {
 	var toks []infix.Tokval
 	for tok := range tokens {
 		toks = append(toks, tok)

--- a/infix/lexer_test.go
+++ b/infix/lexer_test.go
@@ -1,0 +1,101 @@
+package infix_test
+
+import (
+	"github.com/madlambda/bwc/infix"
+	"testing"
+)
+
+func consume(tokens chan infix.Tokval) []infix.Tokval {
+	var toks []infix.Tokval
+	for tok := range tokens {
+		toks = append(toks, tok)
+	}
+	return toks
+}
+
+func TestLexer(t *testing.T) {
+	for _, tc := range []struct {
+		in  string
+		out []infix.Tokval
+	}{
+		{
+			in: "0",
+			out: []infix.Tokval{
+				{
+					T: infix.Number,
+					V: "0",
+				},
+			},
+		},
+		{
+			in: "0123456789",
+			out: []infix.Tokval{
+				{
+					T: infix.Number,
+					V: "0123456789",
+				},
+			},
+		},
+		{
+			in: "0&0",
+			out: []infix.Tokval{
+				{
+					T: infix.Number,
+					V: "0",
+				},
+				{
+					T: infix.AND,
+					V: "&",
+				},
+				{
+					T: infix.Number,
+					V: "0",
+				},
+			},
+		},
+
+		{
+			in: "0&0|1",
+			out: []infix.Tokval{
+				{
+					T: infix.Number,
+					V: "0",
+				},
+				{
+					T: infix.AND,
+					V: "&",
+				},
+				{
+					T: infix.Number,
+					V: "0",
+				},
+				{
+					T: infix.OR,
+					V: "|",
+				},
+				{
+					T: infix.Number,
+					V: "1",
+				},
+			},
+		},
+	} {
+		tc := tc
+		got := consume(infix.Lex(tc.in))
+		if len(got) != len(tc.out) {
+			t.Fatalf("expect %d elems but got %d",
+				len(tc.out), len(got))
+		}
+
+		for i := 0; i < len(tc.out); i++ {
+			e := tc.out[i]
+			g := got[i]
+			if e.T != g.T {
+				t.Fatalf("tok differs: %v != %v", e, g)
+			}
+			if e.V != g.V {
+				t.Fatalf("tok differs: %s != %s", e.V, g.V)
+			}
+		}
+	}
+}

--- a/infix/parser.go
+++ b/infix/parser.go
@@ -55,7 +55,7 @@ func (p *parser) next() Tokval {
 }
 
 func (p *parser) parseExpr() (Node, error) {
-	var eoferr = func (expect string) error {
+	var eoferr = func(expect string) error {
 		return fmt.Errorf("premature eof, expects %s",
 			expect)
 	}
@@ -80,8 +80,12 @@ func (p *parser) parseExpr() (Node, error) {
 		lhs, eof, err = p.parseNum()
 	}
 
-	if err != nil 	{ return nil, err }
-	if eof 			{ return nil, eoferr("expr || number") }
+	if err != nil {
+		return nil, err
+	}
+	if eof {
+		return nil, eoferr("expr || number")
+	}
 
 	if hasparens {
 		tok = p.next()
@@ -91,8 +95,12 @@ func (p *parser) parseExpr() (Node, error) {
 	}
 
 	op, eof, err := p.parseOp()
-	if err != nil 	{ return nil, err }
-	if eof 			{ return lhs, nil }
+	if err != nil {
+		return nil, err
+	}
+	if eof {
+		return lhs, nil
+	}
 
 	// right hand side of expr
 	var rhs Node
@@ -111,8 +119,12 @@ func (p *parser) parseExpr() (Node, error) {
 		rhs, eof, err = p.parseNum()
 	}
 
-	if err != nil 	{ return nil, err }
-	if eof 			{ return nil, eoferr("number") }
+	if err != nil {
+		return nil, err
+	}
+	if eof {
+		return nil, eoferr("number")
+	}
 
 	if hasparens {
 		tok := p.next()
@@ -149,7 +161,7 @@ func (p *parser) parseNum() (a Int, eof bool, err error) {
 			val, err := strconv.ParseInt(intstr[2:], 16, 64)
 			return Int(val), false, err
 		}
-	}	
+	}
 
 	val, err := strconv.ParseInt(intstr, 10, 64)
 	return Int(val), false, err

--- a/infix/parser.go
+++ b/infix/parser.go
@@ -6,7 +6,7 @@ import (
 )
 
 type parser struct {
-	tokens    chan Tokval
+	tokens    <-chan Tokval
 	lookahead []Tokval
 }
 

--- a/infix/parser.go
+++ b/infix/parser.go
@@ -138,7 +138,20 @@ func (p *parser) parseNum() (a Int, eof bool, err error) {
 		return 0, false, parserErr(tok)
 	}
 
-	val, err := strconv.Atoi(tok.V)
+	intstr := tok.V
+	if len(intstr) > 2 {
+		if intstr[1] == 'b' {
+			val, err := strconv.ParseInt(intstr[2:], 2, 64)
+			return Int(val), false, err
+		}
+
+		if intstr[1] == 'x' {
+			val, err := strconv.ParseInt(intstr[2:], 16, 64)
+			return Int(val), false, err
+		}
+	}	
+
+	val, err := strconv.ParseInt(intstr, 10, 64)
 	return Int(val), false, err
 }
 
@@ -161,6 +174,10 @@ func validOperation(tok Token) (Optype, bool) {
 		return OpAND, true
 	case OR:
 		return OpOR, true
+	case SHL:
+		return OpSHL, true
+	case SHR:
+		return OpSHR, true
 	}
 
 	return -1, false

--- a/infix/parser.go
+++ b/infix/parser.go
@@ -2,20 +2,70 @@ package infix
 
 import (
 	"fmt"
+	"strconv"
 )
 
-func Parse(code string) (Expr, error) {
-	tokens := Lex(code)
-	for tok := range tokens {
-		if tok.T == EOF {
-			break
-		}
+type parser struct {
+	tokens chan Tokval
+}
 
-		fmt.Printf("tok: %v\n", tok)
+func Parse(code string) (*Expr, error) {
+	p := &parser{
+		tokens: Lex(code),
 	}
-	return Expr{
-		Op:  1,
-		Lhs: Int(1),
-		Rhs: Int(1),
+	return p.parseExpr()
+}
+
+func parserErr(tok Tokval) error {
+	return fmt.Errorf("unexpected %s", tok)
+}
+
+func (p *parser) parseExpr() (*Expr, error) {
+	ltok := <-p.tokens
+	if ltok.T != Number {
+		return nil, parserErr(ltok)
+	}
+
+	optok := <-p.tokens
+	op, ok := validOperation(optok.T)
+	if !ok {
+		return nil, parserErr(optok)
+	}
+
+	rtok := <-p.tokens
+	if rtok.T != Number {
+		return nil, parserErr(rtok)
+	}
+
+	lhs, err := parseNum(ltok.V)
+	if err != nil {
+		return nil, err
+	}
+
+	rhs, err := parseNum(rtok.V)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Expr{
+		Op:  op,
+		Lhs: lhs,
+		Rhs: rhs,
 	}, nil
+}
+
+func parseNum(num string) (Int, error) {
+	i, err := strconv.Atoi(num)
+	return Int(i), err
+}
+
+func validOperation(tok Token) (Optype, bool) {
+	switch tok {
+	case AND:
+		return OpAND, true
+	case OR:
+		return OpOR, true
+	}
+
+	return -1, false
 }

--- a/infix/parser.go
+++ b/infix/parser.go
@@ -121,7 +121,7 @@ func (p *parser) parseExpr() (Node, error) {
 		}
 	}
 
-	return &Expr{
+	return Expr{
 		Op:  op,
 		Lhs: lhs,
 		Rhs: rhs,

--- a/infix/parser.go
+++ b/infix/parser.go
@@ -2,99 +2,16 @@ package infix
 
 import (
 	"fmt"
-	"strings"
-	"unicode"
-	"unicode/utf8"
 )
-
-type (
-	Lexer struct {
-		input  string // expression being lex'ed
-		start  int    // start position of token
-		pos    int    // pos in the input
-		width  int    // width of last rune
-		tokens chan Tokval
-	}
-
-	stateFn func(*Lexer) stateFn
-
-	// Tokval is the token type + value
-	Tokval struct {
-		T Token
-		V string
-	}
-)
-
-const eof = -1
-
-func Lex(input string) chan Tokval {
-	l := &Lexer{
-		input:  input,
-		tokens: make(chan Tokval),
-	}
-
-	go l.run()
-	return l.tokens
-}
-
-func (l *Lexer) run() {
-	for state := lexExpr; state != nil; {
-		state = state(l)
-	}
-}
-
-func (l *Lexer) emit(tok Token) {
-	l.tokens <- Tokval{
-		T: tok,
-		V: l.input[l.start:l.pos],
-	}
-	l.start = l.pos
-}
-
-func (l *Lexer) errorf(msg string, args ...interface{}) {
-	l.tokens <- Tokval{
-		T: Illegal,
-		V: fmt.Sprintf(msg, args...),
-	}
-	l.start = len(l.input)
-	l.pos = l.start
-}
-
-func (l *Lexer) next() (r rune) {
-	if l.pos >= len(l.input) {
-		return eof
-	}
-	r, l.width = utf8.DecodeRuneInString(l.input[l.pos:])
-	l.pos += l.width
-	return r
-}
-
-func (l *Lexer) backup() {
-	l.pos -= l.width
-}
-
-func (l *Lexer) acceptRun(valid string) {
-	for strings.IndexRune(valid, l.next()) >= 0 {
-	}
-	l.backup()
-}
-
-func lexExpr(l *Lexer) stateFn {
-	r := l.next()
-	switch {
-	case unicode.IsDigit(r):
-		l.acceptRun("xb0123456789")
-		l.emit(Number)
-		return nil
-	default:
-		l.errorf("Unexpected %q at %d", r, l.pos)
-	}
-	return nil
-}
 
 func Parse(code string) (Expr, error) {
-	for tok := range Lex(code) {
-		fmt.Printf("tok: %s\n", tok)
+	tokens := Lex(code)
+	for tok := range tokens {
+		if tok.T == EOF {
+			break
+		}
+
+		fmt.Printf("tok: %v\n", tok)
 	}
 	return Expr{
 		Op:  1,

--- a/infix/parser.go
+++ b/infix/parser.go
@@ -7,44 +7,118 @@ import (
 
 type parser struct {
 	tokens chan Tokval
+	pocket *Tokval // lookahead
 }
 
-func Parse(code string) (*Expr, error) {
-	p := &parser{
-		tokens: Lex(code),
-	}
-	return p.parseExpr()
+var TokEOF = Tokval{
+	T: EOF,
+	V: "<eof>",
 }
 
 func parserErr(tok Tokval) error {
 	return fmt.Errorf("unexpected %s", tok)
 }
 
-func (p *parser) parseExpr() (*Expr, error) {
-	ltok := <-p.tokens
-	if ltok.T != Number {
-		return nil, parserErr(ltok)
+func Parse(code string) (Node, error) {
+	p := &parser{
+		tokens: Lex(code),
+	}
+	return p.parseExpr()
+}
+
+func (p *parser) peek() Tokval {
+	if p.pocket != nil {
+		val := *p.pocket
+		p.pocket = nil
+		return val
 	}
 
-	optok := <-p.tokens
-	op, ok := validOperation(optok.T)
+	val, ok := <-p.tokens
 	if !ok {
-		return nil, parserErr(optok)
+		return TokEOF
+	}
+	p.pocket = &val
+	return val
+}
+
+func (p *parser) next() Tokval {
+	if p.pocket != nil {
+		val := *p.pocket
+		p.pocket = nil
+		return val
+	}
+	tok, ok := <-p.tokens
+	if !ok {
+		return TokEOF
+	}
+	return tok
+}
+
+func (p *parser) parseExpr() (Node, error) {
+	var eoferr = func (expect string) error {
+		return fmt.Errorf("premature eof, expects %s",
+			expect)
 	}
 
-	rtok := <-p.tokens
-	if rtok.T != Number {
-		return nil, parserErr(rtok)
+	tok := p.peek()
+	if tok.T == EOF {
+		return nil, eoferr("expression")
 	}
 
-	lhs, err := parseNum(ltok.V)
-	if err != nil {
-		return nil, err
+	// left hand side of expr
+
+	var lhs Node
+	var err error
+	var eof bool
+
+	var hasparens bool
+	if tok.T == LParen {
+		hasparens = true
+		p.next()
+		lhs, err = p.parseExpr()
+	} else {
+		lhs, eof, err = p.parseNum()
 	}
 
-	rhs, err := parseNum(rtok.V)
-	if err != nil {
-		return nil, err
+	if err != nil 	{ return nil, err }
+	if eof 			{ return nil, eoferr("expr || number") }
+
+	if hasparens {
+		tok = p.next()
+		if tok.T != RParen {
+			return nil, parserErr(tok)
+		}
+	}
+
+	op, eof, err := p.parseOp()
+	if err != nil 	{ return nil, err }
+	if eof 			{ return lhs, nil }
+
+	// right hand side of expr
+	var rhs Node
+	hasparens = false
+
+	tok = p.peek()
+	if tok.T == EOF {
+		return nil, eoferr("rhs of expr")
+	}
+
+	if tok.T == LParen {
+		hasparens = true
+		p.next()
+		rhs, err = p.parseExpr()
+	} else {
+		rhs, eof, err = p.parseNum()
+	}
+
+	if err != nil 	{ return nil, err }
+	if eof 			{ return nil, eoferr("number") }
+
+	if hasparens {
+		tok := p.next()
+		if tok.T != RParen {
+			return nil, parserErr(tok)
+		}
 	}
 
 	return &Expr{
@@ -54,9 +128,31 @@ func (p *parser) parseExpr() (*Expr, error) {
 	}, nil
 }
 
-func parseNum(num string) (Int, error) {
-	i, err := strconv.Atoi(num)
-	return Int(i), err
+func (p *parser) parseNum() (a Int, eof bool, err error) {
+	tok := p.next()
+	if tok.T == EOF {
+		return 0, true, nil
+	}
+
+	if tok.T != Number {
+		return 0, false, parserErr(tok)
+	}
+
+	val, err := strconv.Atoi(tok.V)
+	return Int(val), false, err
+}
+
+func (p *parser) parseOp() (a Optype, eof bool, err error) {
+	optok := p.next()
+	if optok.T == EOF {
+		return 0, true, nil
+	}
+
+	op, ok := validOperation(optok.T)
+	if !ok {
+		return 0, false, parserErr(optok)
+	}
+	return op, false, nil
 }
 
 func validOperation(tok Token) (Optype, bool) {

--- a/infix/parser.go
+++ b/infix/parser.go
@@ -1,0 +1,104 @@
+package infix
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+type (
+	Lexer struct {
+		input  string // expression being lex'ed
+		start  int    // start position of token
+		pos    int    // pos in the input
+		width  int    // width of last rune
+		tokens chan Tokval
+	}
+
+	stateFn func(*Lexer) stateFn
+
+	// Tokval is the token type + value
+	Tokval struct {
+		T Token
+		V string
+	}
+)
+
+const eof = -1
+
+func Lex(input string) chan Tokval {
+	l := &Lexer{
+		input:  input,
+		tokens: make(chan Tokval),
+	}
+
+	go l.run()
+	return l.tokens
+}
+
+func (l *Lexer) run() {
+	for state := lexExpr; state != nil; {
+		state = state(l)
+	}
+}
+
+func (l *Lexer) emit(tok Token) {
+	l.tokens <- Tokval{
+		T: tok,
+		V: l.input[l.start:l.pos],
+	}
+	l.start = l.pos
+}
+
+func (l *Lexer) errorf(msg string, args ...interface{}) {
+	l.tokens <- Tokval{
+		T: Illegal,
+		V: fmt.Sprintf(msg, args...),
+	}
+	l.start = len(l.input)
+	l.pos = l.start
+}
+
+func (l *Lexer) next() (r rune) {
+	if l.pos >= len(l.input) {
+		return eof
+	}
+	r, l.width = utf8.DecodeRuneInString(l.input[l.pos:])
+	l.pos += l.width
+	return r
+}
+
+func (l *Lexer) backup() {
+	l.pos -= l.width
+}
+
+func (l *Lexer) acceptRun(valid string) {
+	for strings.IndexRune(valid, l.next()) >= 0 {
+	}
+	l.backup()
+}
+
+func lexExpr(l *Lexer) stateFn {
+	r := l.next()
+	switch {
+	case unicode.IsDigit(r):
+		l.acceptRun("xb0123456789")
+		l.emit(Number)
+		return nil
+	default:
+		l.errorf("Unexpected %q at %d", r, l.pos)
+	}
+	return nil
+}
+
+func Parse(code string) (Expr, error) {
+	for tok := range Lex(code) {
+		fmt.Printf("tok: %s\n", tok)
+	}
+	return Expr{
+		Op:  1,
+		Lhs: Int(1),
+		Rhs: Int(1),
+	}, nil
+}

--- a/infix/parser_test.go
+++ b/infix/parser_test.go
@@ -1,20 +1,73 @@
 package infix
 
 import (
-	"testing"
 	"reflect"
+	"testing"
 )
 
-func TestParserBinExpr(t *testing.T) {
-	for _, tc := range []struct{
-		code string
-		ast BinExpr
-		err error
+type testcase struct {
+	code string
+	ast  Node
+	err  error
+}
+
+func test(t *testing.T, tc testcase) {
+	t.Helper()
+
+	got, err := Parse(tc.code)
+	if err != tc.err {
+		t.Fatalf("expected(%v) but got(%s)", tc.err, err)
+	}
+
+	if got.Type() != tc.ast.Type() {
+		t.Fatalf("expected type(%s) but got(%s) -> %s", tc.ast.Type(),
+			got.Type(), got)
+	}
+
+	if !reflect.DeepEqual(got, tc.ast) {
+		t.Fatalf("node differs: (%s) != (%s)", got, tc.ast)
+	}
+}
+
+func TestParseAssign(t *testing.T) {
+	for _, tc := range []testcase{
+		{
+			code: "a = 1",
+			ast: Assign{
+				Varname: "a",
+				Expr:    Int(1),
+			},
+		},
+		{
+			code: "a = a",
+			ast: Assign{
+				Varname: "a",
+				Expr:    Var("a"),
+			},
+		},
+		{
+			code: "a = a | b",
+			ast: Assign{
+				Varname: "a",
+				Expr: BinExpr{
+					Lhs: Var("a"),
+					Rhs: Var("b"),
+					Op:  OpOR,
+				},
+			},
+		},
 	} {
+
+		test(t, tc)
+	}
+}
+
+func TestParserBinExpr(t *testing.T) {
+	for _, tc := range []testcase{
 		{
 			code: "0|1",
 			ast: BinExpr{
-				Op: OpOR,
+				Op:  OpOR,
 				Lhs: Int(0),
 				Rhs: Int(1),
 			},
@@ -24,7 +77,7 @@ func TestParserBinExpr(t *testing.T) {
 			ast: BinExpr{
 				Op: OpOR,
 				Lhs: BinExpr{
-					Op: OpOR,
+					Op:  OpOR,
 					Lhs: Int(0),
 					Rhs: Int(1),
 				},
@@ -32,18 +85,6 @@ func TestParserBinExpr(t *testing.T) {
 			},
 		},
 	} {
-		got, err := Parse(tc.code)
-		if err != tc.err {
-			t.Fatalf("expected(%s) but got(%s)", tc.err, err)
-		}
-
-		if got.Type() != tc.ast.Type() {
-			t.Fatalf("expected type(%s) but got(%s) -> %s", tc.ast.Type(),
-				got.Type(), got)
-		}
-
-		if !reflect.DeepEqual(got, tc.ast) {
-			t.Fatalf("node differs: (%s) != (%s)", got, tc.ast)
-		}		
+		test(t, tc)
 	}
 }

--- a/infix/parser_test.go
+++ b/infix/parser_test.go
@@ -1,0 +1,49 @@
+package infix
+
+import (
+	"testing"
+	"reflect"
+)
+
+func TestParserBinExpr(t *testing.T) {
+	for _, tc := range []struct{
+		code string
+		ast BinExpr
+		err error
+	} {
+		{
+			code: "0|1",
+			ast: BinExpr{
+				Op: OpOR,
+				Lhs: Int(0),
+				Rhs: Int(1),
+			},
+		},
+		{
+			code: "0|1|2",
+			ast: BinExpr{
+				Op: OpOR,
+				Lhs: BinExpr{
+					Op: OpOR,
+					Lhs: Int(0),
+					Rhs: Int(1),
+				},
+				Rhs: Int(2),
+			},
+		},
+	} {
+		got, err := Parse(tc.code)
+		if err != tc.err {
+			t.Fatalf("expected(%s) but got(%s)", tc.err, err)
+		}
+
+		if got.Type() != tc.ast.Type() {
+			t.Fatalf("expected type(%s) but got(%s) -> %s", tc.ast.Type(),
+				got.Type(), got)
+		}
+
+		if !reflect.DeepEqual(got, tc.ast) {
+			t.Fatalf("node differs: (%s) != (%s)", got, tc.ast)
+		}		
+	}
+}

--- a/infix/parser_test.go
+++ b/infix/parser_test.go
@@ -84,6 +84,42 @@ func TestParserBinExpr(t *testing.T) {
 				Rhs: Int(2),
 			},
 		},
+		{
+			code: "a|1",
+			ast: BinExpr{
+				Op:  OpOR,
+				Lhs: Var("a"),
+				Rhs: Int(1),
+			},
+		},
+		{
+			code: "(a|1)",
+			ast: BinExpr{
+				Op:  OpOR,
+				Lhs: Var("a"),
+				Rhs: Int(1),
+			},
+		},
+		{
+			code: "((a|1))",
+			ast: BinExpr{
+				Op:  OpOR,
+				Lhs: Var("a"),
+				Rhs: Int(1),
+			},
+		},
+		{
+			code: "((a|1)|2)",
+			ast: BinExpr{
+				Op: OpOR,
+				Lhs: BinExpr{
+					Op:  OpOR,
+					Lhs: Var("a"),
+					Rhs: Int(1),
+				},
+				Rhs: Int(2),
+			},
+		},
 	} {
 		test(t, tc)
 	}

--- a/infix/token.go
+++ b/infix/token.go
@@ -15,6 +15,8 @@ const (
 	RParen
 	OR
 	AND
+	SHL
+	SHR
 	EOF
 )
 

--- a/infix/token.go
+++ b/infix/token.go
@@ -11,4 +11,5 @@ const (
 	OR
 	AND
 	Illegal
+	EOF
 )

--- a/infix/token.go
+++ b/infix/token.go
@@ -1,8 +1,4 @@
-package infix
-
-import (
-	"strconv"
-)
+package infix 
 
 type (
 	Token int
@@ -15,6 +11,8 @@ const (
 	RParen
 	OR
 	AND
+	XOR
+	NOT
 	SHL
 	SHR
 	EOF
@@ -26,8 +24,12 @@ func (t Token) String() string {
 	case RParen: return ")"
 	case OR: return "|"
 	case AND: return "&"
+	case XOR: return "^"
+	case NOT: return "~"
+	case SHL: return "<<"
+	case SHR: return ">>"
 	case Illegal: return "<ileggal>"
 	case EOF: return "EOF"
 	}
-	return strconv.Itoa(int(t))
+	panic("invalid token")
 }

--- a/infix/token.go
+++ b/infix/token.go
@@ -11,5 +11,4 @@ const (
 	OR
 	AND
 	Illegal
-	EOF
 )

--- a/infix/token.go
+++ b/infix/token.go
@@ -1,0 +1,14 @@
+package infix
+
+type (
+	Token int
+)
+
+const (
+	Number Token = iota+1
+	LParen
+	RParen
+	OR
+	AND
+	Illegal
+)

--- a/infix/token.go
+++ b/infix/token.go
@@ -11,4 +11,17 @@ const (
 	OR
 	AND
 	Illegal
+	EOF
 )
+
+func (t Token) String() string {
+	switch t {
+	case LParen: return "("
+	case RParen: return ")"
+	case OR: return "|"
+	case AND: return "&"
+	case Illegal: return "<ileggal>"
+	case EOF: return "EOF"
+	}
+	return "<invalid>"
+}

--- a/infix/token.go
+++ b/infix/token.go
@@ -1,4 +1,6 @@
-package infix 
+package infix
+
+import "fmt"
 
 type (
 	Token int
@@ -6,9 +8,11 @@ type (
 
 const (
 	Illegal Token = iota
+	Ident
 	Number
 	LParen
 	RParen
+	Equal
 	OR
 	AND
 	XOR
@@ -20,16 +24,32 @@ const (
 
 func (t Token) String() string {
 	switch t {
-	case LParen: return "("
-	case RParen: return ")"
-	case OR: return "|"
-	case AND: return "&"
-	case XOR: return "^"
-	case NOT: return "~"
-	case SHL: return "<<"
-	case SHR: return ">>"
-	case Illegal: return "<ileggal>"
-	case EOF: return "EOF"
+	case Ident:
+		return "IDENT"
+	case Number:
+		return "NUMBER"
+	case LParen:
+		return "("
+	case RParen:
+		return ")"
+	case Equal:
+		return "="
+	case OR:
+		return "|"
+	case AND:
+		return "&"
+	case XOR:
+		return "^"
+	case NOT:
+		return "~"
+	case SHL:
+		return "<<"
+	case SHR:
+		return ">>"
+	case Illegal:
+		return "<ileggal>"
+	case EOF:
+		return "EOF"
 	}
-	panic("invalid token")
+	panic(fmt.Sprintf("invalid token: %d", t))
 }

--- a/infix/token.go
+++ b/infix/token.go
@@ -1,16 +1,20 @@
 package infix
 
+import (
+	"strconv"
+)
+
 type (
 	Token int
 )
 
 const (
-	Number Token = iota+1
+	Illegal Token = iota
+	Number
 	LParen
 	RParen
 	OR
 	AND
-	Illegal
 	EOF
 )
 
@@ -23,5 +27,5 @@ func (t Token) String() string {
 	case Illegal: return "<ileggal>"
 	case EOF: return "EOF"
 	}
-	return "<invalid>"
+	return strconv.Itoa(int(t))
 }

--- a/main.go
+++ b/main.go
@@ -2,46 +2,63 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 )
 
 type (
+	Int int64
 	Expr struct {
-		Op  int
+		Op  Optype
 		Lhs Node
 		Rhs Node
 	}
 
 	Node interface {
-		Type() int
+		Type() Nodetype
+		String() string
 	}
 
-	Int int64
+	Nodetype int
+	Optype int
 )
 
 const (
-	Nodetype = iota
-	NodeExpr
+	NodeExpr Nodetype = iota+1
 	NodeInt
 
-	Optype = iota
-	OpAND
+	OpAND Optype = iota+1
 	OpOR
 )
 
-func (_ Int) Type() int { return NodeInt }
-func (_ Expr) Type() int { return NodeExpr }
+func (o Optype) String() string {
+	if o == OpAND 	{ return "&" }
+	if o == OpOR 	{ return "|" }
+	return "<invalid op>"
+}
 
-func eval(tree Expr) Int {
+func (_ Int) Type() Nodetype  { return NodeInt }
+func (i Int) String() string { return strconv.Itoa(int(i)) }
+
+func (_ Expr) Type() Nodetype { return NodeExpr }
+func (a Expr) String() string {
+	lhs := a.Lhs.String()
+	rhs := a.Rhs.String()
+	op := a.Op.String()
+
+	return fmt.Sprintf("%s %s %s", lhs, rhs, op)
+}
+
+func Eval(tree Expr) Int {
 	var lhs, rhs Int
 
 	if tree.Lhs.Type() != NodeInt {
-		lhs = eval(tree.Lhs.(Expr))
+		lhs = Eval(tree.Lhs.(Expr))
 	} else {
 		lhs = tree.Lhs.(Int)
 	}
 
 	if tree.Rhs.Type() != NodeInt {
-		rhs = eval(tree.Rhs.(Expr))
+		rhs = Eval(tree.Rhs.(Expr))
 	} else {
 		rhs = tree.Rhs.(Int)
 	}
@@ -63,5 +80,5 @@ func main() {
 		Rhs: Int(2),
 	}
 
-	fmt.Printf("%d\n", eval(expr))
+	fmt.Printf("%d\n", Eval(expr))
 }

--- a/main.go
+++ b/main.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/madlambda/bwc/infix"
 )
 
 func main() {
 	for {
+		fmt.Printf("bwc> ")
 		var line [256]byte
 		n, err := os.Stdin.Read(line[:])
 		if err == io.EOF {
@@ -20,14 +22,24 @@ func main() {
 			os.Exit(1)
 		}
 
-		tree, err := infix.Parse(string(line[:n-1]))
+		buf := strings.TrimSpace(string(line[:n-1]))
+		if len(buf) == 0 {
+			fmt.Printf("\n")
+			continue
+		}
+
+		tree, err := infix.Parse(buf)
 		if err != nil {
 			fmt.Printf("error: %s\n", err)
 			continue
 		}
 
-		res := infix.Eval(tree)
-		fmt.Printf("bin: %b\n", res)
-		fmt.Printf("hex: %x\n", res)
+		res, err := infix.Eval(tree)
+		if err != nil {
+			fmt.Printf("error: %s\n", err)
+		}
+
+		fmt.Printf("bin: %b\n", int(res))
+		fmt.Printf("hex: %x\n", int(res))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+)
+
+type (
+	Expr struct {
+		Op  int
+		Lhs Node
+		Rhs Node
+	}
+
+	Node interface {
+		Type() int
+	}
+
+	Int int64
+)
+
+const (
+	Nodetype = iota
+	NodeExpr
+	NodeInt
+
+	Optype = iota
+	OpAND
+	OpOR
+)
+
+func (_ Int) Type() int { return NodeInt }
+func (_ Expr) Type() int { return NodeExpr }
+
+func eval(tree Expr) Int {
+	var lhs, rhs Int
+
+	if tree.Lhs.Type() != NodeInt {
+		lhs = eval(tree.Lhs.(Expr))
+	} else {
+		lhs = tree.Lhs.(Int)
+	}
+
+	if tree.Rhs.Type() != NodeInt {
+		rhs = eval(tree.Rhs.(Expr))
+	} else {
+		rhs = tree.Rhs.(Int)
+	}
+
+	var ret Int
+	switch tree.Op {
+	case OpAND:
+		ret = lhs & rhs
+	case OpOR:
+		ret = lhs | rhs
+	}
+	return ret
+}
+
+func main() {
+	expr := Expr{
+		Op:  OpAND,
+		Lhs: Int(1),
+		Rhs: Int(2),
+	}
+
+	fmt.Printf("%d\n", eval(expr))
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 )
 
 func main() {
+	interp := infix.NewInterp()
+
 	for {
 		fmt.Printf("bwc> ")
 		var line [256]byte
@@ -34,7 +36,7 @@ func main() {
 			continue
 		}
 
-		res, err := infix.Eval(tree)
+		res, err := interp.Eval(tree)
 		if err != nil {
 			fmt.Printf("error: %s\n", err)
 		}

--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"io"
+	"os"
 
 	"github.com/madlambda/bwc/infix"
 )
@@ -20,7 +20,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		tree, err := infix.Parse(string(line[:n]))
+		tree, err := infix.Parse(string(line[:n-1]))
 		if err != nil {
 			fmt.Printf("error: %s\n", err)
 			continue

--- a/main.go
+++ b/main.go
@@ -2,83 +2,32 @@ package main
 
 import (
 	"fmt"
-	"strconv"
+	"os"
+	"io"
+
+	"github.com/madlambda/bwc/infix"
 )
-
-type (
-	Int int64
-	Expr struct {
-		Op  Optype
-		Lhs Node
-		Rhs Node
-	}
-
-	Node interface {
-		Type() Nodetype
-		String() string
-	}
-
-	Nodetype int
-	Optype int
-)
-
-const (
-	NodeExpr Nodetype = iota+1
-	NodeInt
-
-	OpAND Optype = iota+1
-	OpOR
-)
-
-func (o Optype) String() string {
-	if o == OpAND 	{ return "&" }
-	if o == OpOR 	{ return "|" }
-	return "<invalid op>"
-}
-
-func (_ Int) Type() Nodetype  { return NodeInt }
-func (i Int) String() string { return strconv.Itoa(int(i)) }
-
-func (_ Expr) Type() Nodetype { return NodeExpr }
-func (a Expr) String() string {
-	lhs := a.Lhs.String()
-	rhs := a.Rhs.String()
-	op := a.Op.String()
-
-	return fmt.Sprintf("%s %s %s", lhs, rhs, op)
-}
-
-func Eval(tree Expr) Int {
-	var lhs, rhs Int
-
-	if tree.Lhs.Type() != NodeInt {
-		lhs = Eval(tree.Lhs.(Expr))
-	} else {
-		lhs = tree.Lhs.(Int)
-	}
-
-	if tree.Rhs.Type() != NodeInt {
-		rhs = Eval(tree.Rhs.(Expr))
-	} else {
-		rhs = tree.Rhs.(Int)
-	}
-
-	var ret Int
-	switch tree.Op {
-	case OpAND:
-		ret = lhs & rhs
-	case OpOR:
-		ret = lhs | rhs
-	}
-	return ret
-}
 
 func main() {
-	expr := Expr{
-		Op:  OpAND,
-		Lhs: Int(1),
-		Rhs: Int(2),
-	}
+	for {
+		var line [256]byte
+		n, err := os.Stdin.Read(line[:])
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "err: %s\n", err)
+			os.Exit(1)
+		}
 
-	fmt.Printf("%d\n", Eval(expr))
+		tree, err := infix.Parse(string(line[:n]))
+		if err != nil {
+			fmt.Printf("error: %s\n", err)
+			continue
+		}
+
+		res := infix.Eval(tree)
+		fmt.Printf("bin: %b\n", res)
+		fmt.Printf("hex: %x\n", res)
+	}
 }

--- a/mkfile
+++ b/mkfile
@@ -1,0 +1,2 @@
+bwc:
+	go build

--- a/mkfile
+++ b/mkfile
@@ -1,2 +1,3 @@
-bwc:
+bwc:V:
 	go build
+

--- a/mkfile
+++ b/mkfile
@@ -1,3 +1,5 @@
 bwc:V:
 	go build
 
+test:V:
+	go test -v ./...


### PR DESCRIPTION
Implements the bitwise calculator.

The language is limited to assignment and expressions. Eg.:

```c
bwc> a = 0b10101010
bin: 10101010
hex: aa
bwc> a&0xff
bin: 10101010
hex: aa
bwc> a|0xff
bin: 11111111
hex: ff
```